### PR TITLE
buffer len should not always reset to 0.

### DIFF
--- a/pkg/batch/writer.go
+++ b/pkg/batch/writer.go
@@ -5,7 +5,6 @@ import (
 	"time"
 )
 
-
 // Writer allows to buffer some items and call the Handler function either when the buffer is full or the timeout is
 // reached. There will also be support for concurrency for high volume. The handler function is supposed to return an
 // array of booleans to indicate whether the transfer was successful or not. It can be replaced with status codes in
@@ -56,7 +55,6 @@ func (w *Writer) Start() {
 			case item := <-w.items:
 				if w.len >= w.cfg.BatchSize {
 					w.processBuffer(context.Background())
-					w.len = 0
 				}
 
 				w.buffer[w.len] = bufferItem{v: item, attempt: 0}


### PR DESCRIPTION
`processBuffer` has already set the right buffer len, it should not be
reset to 0 again.