### PR TITLE
Add support for environment variables in configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ func main() {
 		log.Fatal().Err(err).Msg("cannot read config file")
 	}
 
+	b = []byte(os.ExpandEnv(string(b)))
+
 	var cfg exporter.Config
 	err = yaml.Unmarshal(b, &cfg)
 	if err != nil {


### PR DESCRIPTION
The config file may contain sensitive data such as credentials
for an elasticsearch cluster. To provide the possibility
to store that sensitive data in an other way, support for
environment variables is introduced. Sensitive data can then
be replaced by variables such as ${PASSWORD} and provided by
setting the appropriate environment variables. In kubernetes
the configuration and the sensitive data can be split up into
a configmap and a secret.