### PR TITLE
SSL verification mode option for the Elasticsearch sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ receivers:
       password: # optional
       cloudID: # optional
       apiKey: # optional
+      sslVerificationMode: none # optional, for self signed ssl certificate
       # If set to true, it allows updating the same document in ES (might be useful handling count)
       useEventID: true|false
   	  layout: # Optional

--- a/pkg/sinks/elasticsearch.go
+++ b/pkg/sinks/elasticsearch.go
@@ -3,10 +3,12 @@ package sinks
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
+	"net/http"
 )
 
 type ElasticsearchConfig struct {
@@ -19,16 +21,25 @@ type ElasticsearchConfig struct {
 	// Indexing preferences
 	UseEventID bool   `yaml:"useEventID"`
 	Index      string `yaml:"index"`
+	// SSL settings
+	SslVerificationMode string `yaml:"sslVerificationMode"`
 }
 
 func NewElasticsearch(cfg *ElasticsearchConfig) (*Elasticsearch, error) {
-	client, err := elasticsearch.NewClient(elasticsearch.Config{
+	eCfg := elasticsearch.Config{
 		Addresses: cfg.Hosts,
 		Username:  cfg.Username,
 		Password:  cfg.Password,
 		CloudID:   cfg.CloudID,
 		APIKey:    cfg.APIKey,
-	})
+	}
+	if cfg.SslVerificationMode == "none" {
+		eCfg.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+
+	client, err := elasticsearch.NewClient(eCfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Motivation: ECK creates Elasticsearch cluster with self signed ssl cert endpoint.

This PR adds `sslVerificationMode` option, which allows to trust self signed cert

