### PR TITLE
feature: support leader election

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.7
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.0.0-20190819141258-3544db3b9e44
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
 	"github.com/opsgenie/kubernetes-event-exporter/pkg/sinks"
 )
 
@@ -9,9 +10,10 @@ type Config struct {
 	// Route is the top route that the events will match
 	// TODO: There is currently a tight coupling with route and config, but not with receiver config and sink so
 	// TODO: I am not sure what to do here.
-	LogLevel  string                 `yaml:"logLevel"`
-	Route     Route                  `yaml:"route"`
-	Receivers []sinks.ReceiverConfig `yaml:"receivers"`
+	LogLevel       string                    `yaml:"logLevel"`
+	LeaderElection kube.LeaderElectionConfig `yaml:"leaderElection"`
+	Route          Route                     `yaml:"route"`
+	Receivers      []sinks.ReceiverConfig    `yaml:"receivers"`
 }
 
 func (c *Config) Validate() error {

--- a/pkg/kube/leaderelection.go
+++ b/pkg/kube/leaderelection.go
@@ -1,0 +1,103 @@
+package kube
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+// LeaderElectionConfig is used to enable leader election
+type LeaderElectionConfig struct {
+	Enabled          bool   `yaml:"enabled"`
+	LeaderElectionID string `yaml:"leaderElectionID"`
+}
+
+const (
+	inClusterNamespacePath  = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	defaultLeaderElectionID = "kubernetes-event-exporter"
+	defaultNamespace        = "default" // this is used for local development
+	defaultLeaseDuration    = 15 * time.Second
+	defaultRenewDeadline    = 10 * time.Second
+	defaultRetryPeriod      = 2 * time.Second
+)
+
+// NewResourceLock creates a new config map resource lock for use in a leader
+// election loop
+func newResourceLock(config *rest.Config, leaderElectionID string) (resourcelock.Interface, error) {
+	if leaderElectionID == "" {
+		leaderElectionID = defaultLeaderElectionID
+	}
+
+	leaderElectionNamespace, err := getInClusterNamespace()
+	if err != nil {
+		leaderElectionNamespace = defaultNamespace
+	}
+
+	// Leader id, needs to be unique
+	id, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	id = id + "_" + string(uuid.NewUUID())
+
+	// Construct client for leader election
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return resourcelock.New(resourcelock.ConfigMapsResourceLock,
+		leaderElectionNamespace,
+		leaderElectionID,
+		client.CoreV1(),
+		client.CoordinationV1(),
+		resourcelock.ResourceLockConfig{
+			Identity: id,
+		})
+}
+
+func getInClusterNamespace() (string, error) {
+	// Check whether the namespace file exists.
+	// If not, we are not running in cluster so can't guess the namespace.
+	_, err := os.Stat(inClusterNamespacePath)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("not running in-cluster, please specify leaderElectionIDspace")
+	} else if err != nil {
+		return "", fmt.Errorf("error checking namespace file: %w", err)
+	}
+
+	// Load the namespace file and return its content
+	namespace, err := ioutil.ReadFile(inClusterNamespacePath)
+	if err != nil {
+		return "", fmt.Errorf("error reading namespace file: %w", err)
+	}
+	return string(namespace), nil
+}
+
+// NewLeaderElector return  a leader elector object using client-go
+func NewLeaderElector(leaderElectionID string, config *rest.Config, startFunc func(context.Context), stopFunc func()) (*leaderelection.LeaderElector, error) {
+	resourceLock, err := newResourceLock(config, leaderElectionID)
+	if err != nil {
+		return &leaderelection.LeaderElector{}, err
+	}
+
+	l, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          resourceLock,
+		LeaseDuration: defaultLeaseDuration,
+		RenewDeadline: defaultRenewDeadline,
+		RetryPeriod:   defaultRetryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: startFunc,
+			OnStoppedLeading: stopFunc,
+		},
+	})
+	return l, err
+}


### PR DESCRIPTION
leader election function is disabled by default, and could be enabled by adding the following section in `config.yaml`:

```yaml
leaderElection:
  enabled: true
  leaderElectionID: kubernetes-event-exporter  // this field can be omited, default value is kubernetes-event-exporter
```