### PR TITLE
feature: slack receiver should use webhook instead of token

### DIFF
--- a/pkg/sinks/slack.go
+++ b/pkg/sinks/slack.go
@@ -2,44 +2,41 @@ package sinks
 
 import (
 	"context"
+
 	"github.com/nlopes/slack"
 	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
-	"github.com/rs/zerolog/log"
 )
 
 type SlackConfig struct {
-	Token   string            `yaml:"token"`
-	Channel string            `yaml:"channel"`
-	Message string            `yaml:"message"`
-	Fields  map[string]string `yaml:"fields"`
+	Endpoint string            `yaml:endpoint`
+	Message  string            `yaml:"message"`
+	Fields   map[string]string `yaml:"fields"`
 }
 
 type SlackSink struct {
-	cfg    *SlackConfig
-	client *slack.Client
+	cfg *SlackConfig
 }
 
 func NewSlackSink(cfg *SlackConfig) (Sink, error) {
 	return &SlackSink{
-		cfg:    cfg,
-		client: slack.New(cfg.Token),
+		cfg: cfg,
 	}, nil
 }
 
 func (s *SlackSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
-	channel, err := GetString(ev, s.cfg.Channel)
-	if err != nil {
-		return err
-	}
-
 	message, err := GetString(ev, s.cfg.Message)
 	if err != nil {
 		return err
 	}
 
-	options := []slack.MsgOption{slack.MsgOptionText(message, true)}
+	endpoint, err := GetString(ev, s.cfg.Endpoint)
+	if err != nil {
+		return err
+	}
+
+	fields := make([]slack.AttachmentField, 0)
+
 	if s.cfg.Fields != nil {
-		fields := make([]slack.AttachmentField, 0)
 		for k, v := range s.cfg.Fields {
 			fieldText, err := GetString(ev, v)
 			if err != nil {
@@ -52,12 +49,22 @@ func (s *SlackSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 				Short: false,
 			})
 		}
-		options = append(options, slack.MsgOptionAttachments(slack.Attachment{Fields: fields}))
 	}
 
-	_ch, _ts, _text, err := s.client.SendMessageContext(ctx, channel, options...)
-	log.Debug().Str("ch", _ch).Str("ts", _ts).Str("text", _text).Err(err).Msg("Slack Response")
-	return err
+	attachment := slack.Attachment{
+		Fields: fields,
+	}
+
+	webhookMessage := slack.WebhookMessage{
+		Text:        message,
+		Attachments: []slack.Attachment{attachment},
+	}
+
+	err := slack.PostWebhook(endpoint, &webhookMessage)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *SlackSink) Close() {


### PR DESCRIPTION
https://github.com/opsgenie/kubernetes-event-exporter/issues/30

As slack is depreciating slack tokens, I modifiied slack receiver to use webhook instead of token.

Here is my config for test.

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: event-exporter-cfg
  namespace: monitoring
data:
  config.yaml: |
    route:
      match:
        - receiver: "slack"
    receivers:
      - name: "slack"
        slack:
          endpoint: "https://hooks.slack.com/xxx"
          message: "{{ .Message }}"
          fields:
            namespace: "{{ .Namespace }}"
            reason: "{{ .Reason }}"
```

Below is the output.

<img width="648" alt="スクリーンショット 2020-04-15 19 12 12" src="https://user-images.githubusercontent.com/2588391/79326020-1e8d2f80-7f4d-11ea-9e4f-a9ae02036441.png">
