### PR TITLE
Handle HTTP Status code 201 in the webhook sink

### DIFF
--- a/pkg/sinks/webhook.go
+++ b/pkg/sinks/webhook.go
@@ -51,7 +51,7 @@ func (w *Webhook) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 	body, err := ioutil.ReadAll(resp.Body)
 
 	// TODO: make this prettier please
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return errors.New("not 200: " + string(body))
 	}
 

--- a/pkg/sinks/webhook.go
+++ b/pkg/sinks/webhook.go
@@ -52,7 +52,7 @@ func (w *Webhook) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 
 	// TODO: make this prettier please
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return errors.New("not 200: " + string(body))
+		return errors.New("not 200/201: " + string(body))
 	}
 
 	return nil


### PR DESCRIPTION
We are using https://www.tremor.rs/ event processing system and the REST endpoint returns HTTP status code `201` once the request is successfully processed. 

Adding the small patch to handle `HTTP 201 Created` because it's a success status response code.