### PR TITLE
return err in webhook sink

### DIFF
--- a/pkg/sinks/webhook.go
+++ b/pkg/sinks/webhook.go
@@ -44,11 +44,14 @@ func (w *Webhook) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 
 	// TODO: make this prettier please
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
## Problem
When the webhook URL is incorrect or it fails for some reason we don't log anything.

## Solution
Returning the error from the sink will make it log in https://github.com/opsgenie/kubernetes-event-exporter/blob/master/pkg/exporter/channel_registry.go#L58-L60