### PR TITLE
Fix setting alert priority in OpsGenie sink

### DIFF
--- a/pkg/sinks/opsgenie.go
+++ b/pkg/sinks/opsgenie.go
@@ -48,7 +48,9 @@ func NewOpsgenieSink(config *OpsgenieConfig) (Sink, error) {
 }
 
 func (o *OpsgenieSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
-	request := alert.CreateAlertRequest{}
+	request := alert.CreateAlertRequest{
+		Priority: alert.Priority(o.cfg.Priority),
+	}
 
 	msg, err := GetString(ev, o.cfg.Message)
 	if err != nil {


### PR DESCRIPTION
Currently the OpsGenie sink allows you to configure the alert priority. However, the priority is not taken into account when creating the alert.

This results in all alerts being created as `P3` in OpsGenie, regardless of the configuration.

This PR fixes that issue by passing the value of `o.cfg.Priority` to the `CreateAlertRequest` function call.

The upstream library validates the input value, and will throw an `error` if it doesn't match the expected format (`P1` through `P5`).