### PR TITLE
Fix the condition for StatusCode

### DIFF
--- a/pkg/sinks/webhook.go
+++ b/pkg/sinks/webhook.go
@@ -53,8 +53,8 @@ func (w *Webhook) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 		return err
 	}
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300{
-		return errors.New("not 200/201: " + string(body))
+	if resp.StatusCode < 200 && resp.StatusCode < 300{
+		return errors.New("not 2xx, response : " + string(body))
 	}
 
 	return nil


### PR DESCRIPTION
Incorrect HTTP response status code check, if response code is less than 200 or greater than 300, log the debug error