### PR TITLE
Fix label matching bug

### DIFF
--- a/pkg/exporter/rule.go
+++ b/pkg/exporter/rule.go
@@ -62,7 +62,7 @@ func (r *Rule) MatchesEvent(ev *kube.EnhancedEvent) bool {
 			if val, ok := ev.InvolvedObject.Labels[k]; !ok {
 				return false
 			} else {
-				matches := matchString(val, v)
+				matches := matchString(v, val)
 				if !matches {
 					return false
 				}

--- a/pkg/exporter/rule_test.go
+++ b/pkg/exporter/rule_test.go
@@ -52,6 +52,21 @@ func TestBasicRegexRule(t *testing.T) {
 	assert.False(t, r.MatchesEvent(ev3))
 }
 
+func TestLabelRegexRule(t *testing.T) {
+	ev := &kube.EnhancedEvent{}
+	ev.InvolvedObject.Labels = map[string]string{
+		"version": "alpha-123",
+	}
+
+	r := Rule{
+		Labels: map[string]string{
+			"version": "alpha",
+		},
+	}
+
+	assert.True(t, r.MatchesEvent(ev))
+}
+
 func TestOneLabelMatchesRule(t *testing.T) {
 	ev := &kube.EnhancedEvent{}
 	ev.InvolvedObject.Labels = map[string]string{


### PR DESCRIPTION
Use the configured label value from the rule as the regex pattern. Currently it is trying to match the value from the config using the object's label as the pattern, which is incorrect. See also the Annotations matching below (line 79) which is doing it correctly.