### PR TITLE
support multi arch images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.14 AS builder
 
 ADD . /app
 WORKDIR /app
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO11MODULE=on go build -mod=vendor -a -o /main .
+RUN CGO_ENABLED=0 GOOS=linux GO11MODULE=on go build -mod=vendor -a -o /main .
 
 FROM gcr.io/distroless/base
 COPY --from=builder /main /kubernetes-event-exporter


### PR DESCRIPTION
remove `GOARCH` env in Dockerfile to support multi arch images.

Building multi arch images is easy with `docker buildx`:

* enable `docker buildx` feature following the [docs](https://docs.docker.com/buildx/working-with-buildx/)
* run `docker buildx create --name builder --use` to create a builder instance(only need run once)
* run following command to build and push muti arch images: `docker buildx build --platform linux/amd64,linux/arm64 -t opsgenie/kubernetes-event-exporter:v0.9 --push .`