### PR TITLE
Improve slack attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ receivers:
       token: YOUR-API-TOKEN-HERE
       channel: "@{{ .InvolvedObject.Labels.owner }}"
       message: "{{ .Message }}"
+      color: # optional
+      title: # optional
+      author_name: # optional
+      footer: # optional
       fields:
         namespace: "{{ .Namespace }}"
         reason: "{{ .Reason }}"

--- a/pkg/sinks/slack.go
+++ b/pkg/sinks/slack.go
@@ -8,10 +8,14 @@ import (
 )
 
 type SlackConfig struct {
-	Token   string            `yaml:"token"`
-	Channel string            `yaml:"channel"`
-	Message string            `yaml:"message"`
-	Fields  map[string]string `yaml:"fields"`
+	Token      string            `yaml:"token"`
+	Channel    string            `yaml:"channel"`
+	Message    string            `yaml:"message"`
+	Color      string            `yaml:"color"`
+	Footer     string            `yaml:"footer"`
+	Title      string            `yaml:"title"`
+	AuthorName string            `yaml:"author_name"`
+	Fields     map[string]string `yaml:"fields"`
 }
 
 type SlackSink struct {
@@ -52,7 +56,24 @@ func (s *SlackSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 				Short: false,
 			})
 		}
-		options = append(options, slack.MsgOptionAttachments(slack.Attachment{Fields: fields}))
+
+		// make slack attachment
+		slackAttachment := slack.Attachment{}
+		slackAttachment.Fields = fields
+		if s.cfg.AuthorName != "" {
+			slackAttachment.AuthorName = s.cfg.AuthorName
+		}
+		if s.cfg.Color != "" {
+			slackAttachment.Color = s.cfg.Color
+		}
+		if s.cfg.Title != "" {
+			slackAttachment.Title = s.cfg.Title
+		}
+		if s.cfg.Footer != "" {
+			slackAttachment.Footer = s.cfg.Footer
+		}
+
+		options = append(options, slack.MsgOptionAttachments(slackAttachment))
 	}
 
 	_ch, _ts, _text, err := s.client.SendMessageContext(ctx, channel, options...)


### PR DESCRIPTION
This PR makes user can write more flexible slack attachment such as "color", "footer", and so on. (optional)

This is a new example.

```yaml
      - name: "slack"
        slack:
          token: your_token
          channel: your_channel
          color: "#abcdef"
          message: "{{ .Message }}"
          title: "More detail"
          author_name: "generated by kubernetes-event-exporter"
          footer: https://github.com/opsgenie/kubernetes-event-exporter
          fields:
            Reason: "{{ .Reason }}"
            Namespace: "{{ .InvolvedObject.Namespace }}"
            Kind: "{{ .InvolvedObject.Kind }}"
            Name: "{{ .InvolvedObject.Name }}"
            Host: "{{ .Source.Host }}"
```

<img width="247" alt="sample slack message" src="https://user-images.githubusercontent.com/1947929/96095852-26348d80-0f0a-11eb-9dec-d63bc8af8cc5.png">
