### PR TITLE
Do not ignore events created more than 5 seconds ago

### DIFF
--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -1,13 +1,14 @@
 package kube
 
 import (
+	"time"
+
 	"github.com/rs/zerolog/log"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"time"
 )
 
 type EventHandler func(event *EnhancedEvent)
@@ -51,7 +52,7 @@ func (e *EventWatcher) OnUpdate(oldObj, newObj interface{}) {
 func (e *EventWatcher) onEvent(event *corev1.Event) {
 	// TODO: Re-enable this after development
 	// It's probably an old event we are catching, it's not the best way but anyways
-	if time.Now().Sub(event.CreationTimestamp.Time) > time.Second*5 {
+	if time.Since(event.LastTimestamp.Time) > time.Second*5 {
 		return
 	}
 

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -52,7 +52,7 @@ func (e *EventWatcher) OnUpdate(oldObj, newObj interface{}) {
 func (e *EventWatcher) onEvent(event *corev1.Event) {
 	// TODO: Re-enable this after development
 	// It's probably an old event we are catching, it's not the best way but anyways
-	if time.Since(event.LastTimestamp.Time) > time.Second*5 {
+	if time.Since(event.LastTimestamp.Time) > time.Second*60 {
 		return
 	}
 


### PR DESCRIPTION
Currently `kubernetes-event-exporter` will ignore an event if it was created more than 5 seconds ago. In some situations this can lead to important recurring events being silently dropped.

This PR changes this behavior to the following:
1. Check `LastTimestamp` (the time of the last occurrence of this event) instead of `CreationTimestamp`.
2. If more than 1 minute has passed since `LastTimestamp` then this must be an older event that the exporter is somehow catching just now and should be ignored.

Fixes #90