### PR TITLE
Syslog sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,22 @@ receivers:
       layout: # Optional
 ```
 
+### Syslog
+
+Syslog sink support enables to write k8s-events to syslog daemon server over tcp/udp. This can also be consumed by
+ rsyslog. 
+
+```yaml
+# ...
+receivers:
+  - name: "syslog"
+    syslog:
+      network: "tcp"
+      address: "127.0.0.1:11514"
+      tag: "k8s.event"
+
+```
+
 # BigQuery
 
 Google's query thing

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -86,3 +86,8 @@ receivers:
       gcloud_project_id: "my-project"
       topic: "kube-event"
       create_topic: False
+  - name: "syslog"
+    syslog:
+      network: "tcp"
+      address: "127.0.0.1:11514"
+      tag: "k8s.event"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/opsgenie/kubernetes-event-exporter
 go 1.14
 
 require (
-    cloud.google.com/go v0.60.0 // indirect
+       cloud.google.com/go v0.60.0 // indirect
 	cloud.google.com/go/bigquery v1.9.0
 	cloud.google.com/go/pubsub v1.3.1
 	github.com/Masterminds/goutils v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/opsgenie/kubernetes-event-exporter
 go 1.14
 
 require (
-	cloud.google.com/go v0.60.0 // indirect
 	cloud.google.com/go/bigquery v1.9.0
 	cloud.google.com/go/pubsub v1.3.1
 	github.com/Masterminds/goutils v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/opsgenie/kubernetes-event-exporter
 go 1.14
 
 require (
+    cloud.google.com/go v0.60.0 // indirect
 	cloud.google.com/go/bigquery v1.9.0
 	cloud.google.com/go/pubsub v1.3.1
 	github.com/Masterminds/goutils v1.1.0 // indirect

--- a/pkg/sinks/receiver.go
+++ b/pkg/sinks/receiver.go
@@ -8,6 +8,7 @@ type ReceiverConfig struct {
 	InMemory      *InMemoryConfig      `yaml:"inMemory"`
 	Webhook       *WebhookConfig       `yaml:"webhook"`
 	File          *FileConfig          `yaml:"file"`
+	Syslog        *SyslogConfig        `yaml:"syslog"`
 	Elasticsearch *ElasticsearchConfig `yaml:"elasticsearch"`
 	Kinesis       *KinesisConfig       `yaml:"kinesis"`
 	Opsgenie      *OpsgenieConfig      `yaml:"opsgenie"`
@@ -41,6 +42,10 @@ func (r *ReceiverConfig) GetSink() (Sink, error) {
 
 	if r.File != nil {
 		return NewFileSink(r.File)
+	}
+
+	if r.Syslog != nil {
+		return NewSyslogSink(r.Syslog)
 	}
 
 	if r.Elasticsearch != nil {

--- a/pkg/sinks/syslog.go
+++ b/pkg/sinks/syslog.go
@@ -1,0 +1,44 @@
+package sinks
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
+	"log/syslog"
+)
+
+type SyslogConfig struct {
+	Network string `yaml:"network"`
+	Address string `yaml:"address"`
+	Tag     string `yaml:"tag"`
+}
+
+type SyslogSink struct {
+	sw *syslog.Writer
+}
+
+func NewSyslogSink(config *SyslogConfig) (Sink, error) {
+	w, err := syslog.Dial(config.Network, config.Address, syslog.LOG_LOCAL0, config.Tag)
+	if err != nil {
+		return nil, err
+	}
+	return &SyslogSink{sw: w}, nil
+}
+
+func (w *SyslogSink) Close() {
+	w.sw.Close()
+}
+
+func (w *SyslogSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+
+	if b, err := json.Marshal(ev); err == nil {
+		_, writeErr := w.sw.Write(b)
+
+		if writeErr != nil {
+			return writeErr
+		}
+	} else {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Syslog sink support enables to write k8s-events to syslog daemon server over tcp/udp. This can also be consumed by
 rsyslog. 
 
@mustafaakin please review this request.