### PR TITLE
elasticsearch: Add TLS client cert auth

### DIFF
--- a/pkg/sinks/elasticsearch.go
+++ b/pkg/sinks/elasticsearch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"github.com/elastic/go-elasticsearch/v7"
@@ -53,6 +54,8 @@ func NewElasticsearch(cfg *ElasticsearchConfig) (*Elasticsearch, error) {
 		InsecureSkipVerify: cfg.TLS.InsecureSkipVerify,
 		ServerName:         cfg.TLS.ServerName,
 	}
+
+	tlsClientConfig.RootCAs = x509.NewCertPool()
 	tlsClientConfig.RootCAs.AppendCertsFromPEM(caCert)
 
 	cert, err := tls.LoadX509KeyPair(cfg.TLS.CertFile, cfg.TLS.KeyFile)


### PR DESCRIPTION
OpenDistroForElasticsearch makes heavy use of TLS client auth. To ship to those clusters we need TLS client authentication in this exporter.