### PR TITLE
Changed Dockerfile to run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,8 @@ WORKDIR /app
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO11MODULE=on go build -mod=vendor -a -o /main .
 
 FROM gcr.io/distroless/base
-COPY --from=builder /main /kubernetes-event-exporter
+COPY --from=builder --chown=nonroot:nonroot /main /kubernetes-event-exporter
+
+USER nonroot
+
 ENTRYPOINT ["/kubernetes-event-exporter"]


### PR DESCRIPTION
Based on a security tool check this MR, changes the dockerfile user to run as nonroot user ( already present on the `gcr.io/distroless/base` parent image).

Security scan (stackrox) findings/violations found on opsgenie/kubernetes-event-exporter:0.9 docker image:

````
✗ Image opsgenie/kubernetes-event-exporter:0.9 failed policy 'Docker CIS 4.1: Ensure That a User for the Container Has Been Created' 
- Description:
    ↳ Containers should run as a non-root user
- Rationale:
    ↳ It is good practice to run the container as a non-root user, where possible.
      This can be done via the USER directive in the Dockerfile.
- Remediation:
    ↳ Ensure that the Dockerfile for each container switches from the root user
- Violations:
    - Image has user 'root'

✗ Image opsgenie/kubernetes-event-exporter:0.9 failed policy '90-Day Image Age' 
- Description:
    ↳ Alert on deployments with images that haven't been updated in 90 days
- Rationale:
    ↳ Base images are updated frequently with bug fixes and vulnerability patches.
      Image age exceeding 90 days may indicate a higher risk of vulnerabilities
      existing in the image.
- Remediation:
    ↳ Rebuild your image, push a new minor version (with a new immutable tag), and
      update your service to use it.
- Violations:
    - Image was created at 2020-08-22 15:30:34 (UTC)

✗ Image opsgenie/kubernetes-event-exporter:0.9 failed policy 'Docker CIS 4.4: Ensure images are scanned and rebuilt to include security patches' 
- Description:
    ↳ Images should be scanned frequently for any vulnerabilities. You should rebuild
      all images to include these patches and then instantiate new containers from
      them.
- Rationale:
    ↳ Vulnerabilities are loopholes or bugs that can be exploited by hackers or
      malicious users, and security patches are updates to resolve these
      vulnerabilities. Image vulnerability scanning tools can be use to find
      vulnerabilities in images and then check for available patches to mitigate
      these. Patches update the system to a more recent code base which does not
      contain these problems, and being on a supported version of the code base is
      very important, as vendors do not tend to supply patches for older versions
      which have gone out of support. Security patches should be evaluated before
      applying and patching should be implemented in line with the organization's IT
      Security Policy. Care should be taken with the results returned by vulnerability
      assessment tools, as some will simply return results based on software banners,
      and these may not be entirely accurate.
- Remediation:
    ↳ Images should be re-built ensuring that the latest version of the base images
      are used, to keep the operating system patch level at an appropriate level. Once
      the images have been re-built, containers should be re-started making use of the
      updated images.
- Violations:
    - Fixable CVE-2020-1971 (CVSS 5.9) found in component 'openssl' (version 1.1.0l-1~deb9u1), resolved by version 1.1.0l-1~deb9u2
    - Fixable CVE-2021-23840 (CVSS 7.5) found in component 'openssl' (version 1.1.0l-1~deb9u1), resolved by version 1.1.0l-1~deb9u3
    - Fixable CVE-2021-23841 (CVSS 5.9) found in component 'openssl' (version 1.1.0l-1~deb9u1), resolved by version 1.1.0l-1~deb9u3

✗ Image opsgenie/kubernetes-event-exporter:0.9 failed policy 'Fixable CVSS >= 7' (policy enforcement caused failure)
- Description:
    ↳ Alert on deployments with fixable vulnerabilities with a CVSS of at least 7
- Rationale:
    ↳ Known vulnerabilities make it easier for adversaries to exploit your
      application. You can fix these high-severity vulnerabilities by updating to a
      newer version of the affected component(s).
- Remediation:
    ↳ Use your package manager to update to a fixed version in future builds or speak
      with your security team to mitigate the vulnerabilities.
- Violations:
    - Fixable CVE-2021-23840 (CVSS 7.5) found in component 'openssl' (version 1.1.0l-1~deb9u1), resolved by version 1.1.0l-1~deb9u3

✗ Image opsgenie/kubernetes-event-exporter:0.9 failed policy 'CDE - 60-Day Image Age' 
- Description:
    ↳ Alert on deployments with images that haven't been updated in 90 days
- Rationale:
    ↳ Base images are updated frequently with bug fixes and vulnerability patches.
      Image age exceeding 90 days may indicate a higher risk of vulnerabilities
      existing in the image.
      
      PCI-DSS Compliance requires regular patching to be done. Compliance may be at
      risk.
- Remediation:
    ↳ Rebuild your image, push a new minor version (with a new immutable tag), and
      update your service to use it.
- Violations:
    - Image was created at 2020-08-22 15:30:34 (UTC)

````

The other violations found are already fixed  on the parent image