### PR TITLE
Add pipe sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,16 @@ receivers:
         interval_seconds:
         timeout_seconds:
 ```
+# Pipe
 
+pipe output directly into some file descriptor
+
+```yaml
+receivers:
+  - name: "my_pipe"
+    pipe:
+      path: "/dev/stdout"
+```
 ### Planned Receivers
 
 - Big Query

--- a/pkg/sinks/pipe.go
+++ b/pkg/sinks/pipe.go
@@ -1,0 +1,55 @@
+package sinks
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
+)
+
+type PipeConfig struct {
+	Path       string                 `yaml:"path"`
+	Layout     map[string]interface{} `yaml:"layout"`
+}
+
+func (f *PipeConfig) Validate() error {
+	return nil
+}
+
+type Pipe struct {
+	writer  io.WriteCloser
+	encoder *json.Encoder
+	layout  map[string]interface{}
+}
+
+func NewPipeSink(config *PipeConfig) (*Pipe, error) {
+	mode := os.FileMode(0644)
+	f, err := os.OpenFile(config.Path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+    if err != nil {
+        return nil,err
+    }
+	return &Pipe{
+		writer:  f,
+		encoder: json.NewEncoder(f),
+		layout:  config.Layout,
+	}, nil
+}
+
+func (f *Pipe) Close() {
+	_ = f.writer.Close()
+}
+
+func (f *Pipe) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	if f.layout == nil {
+		return f.encoder.Encode(ev)
+	}
+
+	res, err := convertLayoutTemplate(f.layout, ev)
+	if err != nil {
+		return err
+	}
+
+	return f.encoder.Encode(res)
+}

--- a/pkg/sinks/receiver.go
+++ b/pkg/sinks/receiver.go
@@ -35,6 +35,10 @@ func (r *ReceiverConfig) GetSink() (Sink, error) {
 	}
 
 	// Sorry for this code, but its Go
+	if r.Pipe != nil {
+		return NewPipeSink(r.Pipe)
+	}
+
 	if r.Webhook != nil {
 		return NewWebhook(r.Webhook)
 	}

--- a/pkg/sinks/receiver.go
+++ b/pkg/sinks/receiver.go
@@ -19,6 +19,7 @@ type ReceiverConfig struct {
 	Opscenter     *OpsCenterConfig     `yaml:"opscenter"`
 	Teams         *TeamsConfig         `yaml:"teams"`
 	BigQuery      *BigQueryConfig      `yaml:"bigquery"`
+	Pipe          *PipeConfig          `yaml:"pipe"`
 }
 
 func (r *ReceiverConfig) Validate() error {


### PR DESCRIPTION
added pipe support to pipe output directly to a given file.

Usefull for exporting to Stdout or Socket file without rotation in contrast to file sink.