### PR TITLE
Add firehose sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Firehose is an AWS service providing high throughput message collection for use 
 # ...
 receivers:
   - name: "firehose"
-    kineis:
+    firehose:
       deliveryStreamName: "events-pipeline"
       region: us-west-2
       layout: # Optional

--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ receivers:
       layout: # Optional
 ```
 
+### Firehose
+
+Firehose is an AWS service providing high throughput message collection for use in stream processing.
+
+```yaml
+# ...
+receivers:
+  - name: "firehose"
+    kineis:
+      deliveryStreamName: "events-pipeline"
+      region: us-west-2
+      layout: # Optional
+```
 ### SNS
 
 SNS is an AWS service for highly durable pub/sub messaging system.

--- a/pkg/sinks/firehose.go
+++ b/pkg/sinks/firehose.go
@@ -1,5 +1,66 @@
 package sinks
 
-type Firehose struct {
+import (
+	"context"
+	"encoding/json"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
+)
 
+type FirehoseConfig struct {
+	DeliveryStreamName string                 `yaml:"deliveryStreamName"`
+	Region             string                 `yaml:"region"`
+	Layout             map[string]interface{} `yaml:"layout"`
+}
+
+type FirehoseSink struct {
+	cfg *FirehoseConfig
+	svc *firehose.Firehose
+}
+
+func NewFirehoseSink(cfg *FirehoseConfig) (Sink, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(cfg.Region)},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FirehoseSink{
+		cfg: cfg,
+		svc: firehose.New(sess),
+	}, nil
+}
+
+func (f *FirehoseSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
+	var toSend []byte
+
+	if f.cfg.Layout != nil {
+		res, err := convertLayoutTemplate(f.cfg.Layout, ev)
+		if err != nil {
+			return err
+		}
+
+		toSend, err = json.Marshal(res)
+		if err != nil {
+			return err
+		}
+	} else {
+		toSend = ev.ToJSON()
+	}
+
+	_, err := f.svc.PutRecord(&firehose.PutRecordInput{
+		Record: &firehose.Record{
+			Data: toSend,
+		},
+		DeliveryStreamName: aws.String(f.cfg.DeliveryStreamName),
+	})
+
+	return err
+}
+
+func (f *FirehoseSink) Close() {
+	// No-op
 }

--- a/pkg/sinks/receiver.go
+++ b/pkg/sinks/receiver.go
@@ -12,6 +12,7 @@ type ReceiverConfig struct {
 	Stdout        *StdoutConfig        `yaml:"stdout"`
 	Elasticsearch *ElasticsearchConfig `yaml:"elasticsearch"`
 	Kinesis       *KinesisConfig       `yaml:"kinesis"`
+	Firehose      *FirehoseConfig      `yaml:"firehose"`
 	Opsgenie      *OpsgenieConfig      `yaml:"opsgenie"`
 	SQS           *SQSConfig           `yaml:"sqs"`
 	SNS           *SNSConfig           `yaml:"sns"`
@@ -65,6 +66,10 @@ func (r *ReceiverConfig) GetSink() (Sink, error) {
 
 	if r.Kinesis != nil {
 		return NewKinesisSink(r.Kinesis)
+	}
+
+	if r.Firehose != nil {
+		return NewFirehoseSink(r.Firehose)
 	}
 
 	if r.Opsgenie != nil {


### PR DESCRIPTION
Adds a sink for the [Amazon Kinesis Data Firehose](https://aws.amazon.com/kinesis/data-firehose/).

I've made a docker image available for testing here: https://quay.io/repository/alias-dev/kubernetes-event-exporter?tab=tags