### PR TITLE
Support SASL connection for Kafka and add function to get time format ISO8601

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,14 +234,28 @@ Kafka is a popular tool used for real-time data pipelines. You can combine it wi
 receivers:
   - name: "kafka"
     kafka:
+      clientId: "kubernetes"
       topic: "kube-event"
       brokers:
         - "localhost:9092"
+      compressionCodec: "snappy"
       tls:
-        enable: false
+        enable: true
         certFile: "kafka-client.crt"
         keyFile: "kafka-client.key"
         caFile: "kafka-ca.crt"
+      sasl:
+        enable: true
+        username: "kube-event-producer"
+        passsord: "kube-event-producer-password"
+      layout: #optionnal
+        kind: {{ .InvolvedObject.Kind }}
+        namespace: {{ .InvolvedObject.Namespace }}
+        name: {{ .InvolvedObject.Name }}
+        reason: {{ .Reason }}
+        message: {{ .Message }}
+        type: {{ .Type }}
+        createdAt: {{ .GetTimestampISO8601 }}
 ```
 
 ### OpsCenter

--- a/pkg/kube/event.go
+++ b/pkg/kube/event.go
@@ -52,3 +52,8 @@ func (e *EnhancedEvent) ToJSON() []byte {
 func (e *EnhancedEvent) GetTimestampMs() int64 {
 	return e.FirstTimestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
 }
+
+func (e *EnhancedEvent) GetTimestampISO8601() string {
+	layout := "2006-01-02T15:04:05.000Z"
+	return e.FirstTimestamp.Format(layout)
+}

--- a/pkg/sinks/kafka.go
+++ b/pkg/sinks/kafka.go
@@ -6,6 +6,8 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"io/ioutil"
+	"math/rand"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
@@ -14,9 +16,15 @@ import (
 
 // KafkaConfig is the Kafka producer configuration
 type KafkaConfig struct {
-	Topic   string                 `yaml:"topic"`
-	Brokers []string               `yaml:"brokers"`
-	Layout  map[string]interface{} `yaml:"layout"`
+	Topic        	 string                 `yaml:"topic"`
+	Brokers      	 []string               `yaml:"brokers"`
+	Layout       	 map[string]interface{} `yaml:"layout"`
+	ClientId     	 string                 `yaml:"clientId"`
+	Version      	 string                 `yaml:"version"`
+	MaxBytesSize 	 int                    `yaml:"maxBytesSize" default:"1000000"`
+	Timeout      	 int32                  `yaml:"timeout" default:"10"`
+	CompressionCodec string					`yaml:"compressionCodec" default:"none"`
+	KeepAlive        int32					`yaml:"keepAlive" default:"0"`
 	TLS     struct {
 		Enable             bool   `yaml:"enable"`
 		CaFile             string `yaml:"caFile"`
@@ -24,12 +32,25 @@ type KafkaConfig struct {
 		KeyFile            string `yaml:"keyFile"`
 		InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
 	} `yaml:"tls"`
+	SASL struct {
+		Enable    bool   `yaml:"enable"`
+		Username  string `yaml:"username"`
+		Password  string `yaml:"password"`
+	} `yaml:"sasl"`
 }
 
 // KafkaSink is a sink that sends events to a Kafka topic
 type KafkaSink struct {
 	producer sarama.SyncProducer
 	cfg      *KafkaConfig
+}
+
+var CompressionCodecs = map[string]sarama.CompressionCodec{
+	"none": sarama.CompressionNone,
+	"snappy": sarama.CompressionSnappy,
+	"gzip": sarama.CompressionGZIP,
+	"lz4": sarama.CompressionLZ4,
+	"zstd": sarama.CompressionZSTD,
 }
 
 func NewKafkaSink(cfg *KafkaConfig) (Sink, error) {
@@ -88,17 +109,24 @@ func createSaramaProducer(cfg *KafkaConfig) (sarama.SyncProducer, error) {
 	// Default Sarama config
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.MaxVersion
+	saramaConfig.Metadata.Full = true
+	saramaConfig.ClientID = cfg.ClientId
 
 	// Necessary for SyncProducer
 	saramaConfig.Producer.Return.Successes = true
 	saramaConfig.Producer.Return.Errors = true
+	if _, ok := CompressionCodecs[cfg.CompressionCodec]; ok {
+		saramaConfig.Producer.Compression = CompressionCodecs[cfg.CompressionCodec]
+	}
+	saramaConfig.Producer.MaxMessageBytes = cfg.MaxBytesSize
+	saramaConfig.Producer.Timeout = time.Duration(rand.Int31n(cfg.Timeout)) * time.Second
+
+	// Net Config
+	saramaConfig.Net.KeepAlive = time.Duration(rand.Int31n(cfg.KeepAlive)) * time.Second
 
 	// TLS Client auth override
 	if cfg.TLS.Enable {
-		cert, err := tls.LoadX509KeyPair(cfg.TLS.CertFile, cfg.TLS.KeyFile)
-		if err != nil {
-			return nil, err
-		}
+
 		caCert, err := ioutil.ReadFile(cfg.TLS.CaFile)
 		if err != nil {
 			return nil, err
@@ -109,10 +137,25 @@ func createSaramaProducer(cfg *KafkaConfig) (sarama.SyncProducer, error) {
 
 		saramaConfig.Net.TLS.Enable = true
 		saramaConfig.Net.TLS.Config = &tls.Config{
-			Certificates:       []tls.Certificate{cert},
 			RootCAs:            caCertPool,
 			InsecureSkipVerify: cfg.TLS.InsecureSkipVerify,
 		}
+
+		if cfg.TLS.CertFile != "" && cfg.TLS.KeyFile != "" {
+			cert, err := tls.LoadX509KeyPair(cfg.TLS.CertFile, cfg.TLS.KeyFile)
+			if err != nil {
+				return nil, err
+			}
+
+			saramaConfig.Net.TLS.Config.Certificates = []tls.Certificate{cert}
+		}
+	}
+
+	// SASL Client auth
+	if cfg.SASL.Enable {
+		saramaConfig.Net.SASL.Enable = true
+		saramaConfig.Net.SASL.User = cfg.SASL.Username
+		saramaConfig.Net.SASL.Password = cfg.SASL.Password
 	}
 
 	// TODO: Find a generic way to override all other configs

--- a/pkg/sinks/kafka.go
+++ b/pkg/sinks/kafka.go
@@ -5,13 +5,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
-	"math/rand"
-	"time"
-
 	"github.com/Shopify/sarama"
 	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
 	"github.com/rs/zerolog/log"
+	"io/ioutil"
 )
 
 // KafkaConfig is the Kafka producer configuration
@@ -20,11 +17,7 @@ type KafkaConfig struct {
 	Brokers      	 []string               `yaml:"brokers"`
 	Layout       	 map[string]interface{} `yaml:"layout"`
 	ClientId     	 string                 `yaml:"clientId"`
-	Version      	 string                 `yaml:"version"`
-	MaxBytesSize 	 int                    `yaml:"maxBytesSize" default:"1000000"`
-	Timeout      	 int32                  `yaml:"timeout" default:"10"`
 	CompressionCodec string					`yaml:"compressionCodec" default:"none"`
-	KeepAlive        int32					`yaml:"keepAlive" default:"0"`
 	TLS     struct {
 		Enable             bool   `yaml:"enable"`
 		CaFile             string `yaml:"caFile"`
@@ -118,11 +111,6 @@ func createSaramaProducer(cfg *KafkaConfig) (sarama.SyncProducer, error) {
 	if _, ok := CompressionCodecs[cfg.CompressionCodec]; ok {
 		saramaConfig.Producer.Compression = CompressionCodecs[cfg.CompressionCodec]
 	}
-	saramaConfig.Producer.MaxMessageBytes = cfg.MaxBytesSize
-	saramaConfig.Producer.Timeout = time.Duration(rand.Int31n(cfg.Timeout)) * time.Second
-
-	// Net Config
-	saramaConfig.Net.KeepAlive = time.Duration(rand.Int31n(cfg.KeepAlive)) * time.Second
 
 	// TLS Client auth override
 	if cfg.TLS.Enable {


### PR DESCRIPTION
Hi,
This pull request resolve #62 and resolve #124.
We need it to send event to Kafka with SASL auth and have dates in date format in elasticsearch when using layout.

Documentation for kafka SASL Auth is aded in readme and add example with use of fonction .GetTimestampISO8601 to send date fields in recognized format for elasticsearch.