### PR TITLE
make channel registry asynchronous

### DIFF
--- a/pkg/exporter/channel_registry.go
+++ b/pkg/exporter/channel_registry.go
@@ -54,10 +54,12 @@ func (r *ChannelBasedReceiverRegistry) Register(name string, receiver sinks.Sink
 			select {
 			case ev := <-ch:
 				log.Debug().Str("sink", name).Str("event", ev.Message).Msg("sending event to sink")
-				err := receiver.Send(context.Background(), &ev)
-				if err != nil {
-					log.Debug().Err(err).Str("sink", name).Str("event", ev.Message).Msg("Cannot send event")
-				}
+				go func() {
+					err := receiver.Send(context.Background(), &ev)
+					if err != nil {
+						log.Debug().Err(err).Str("sink", name).Str("event", ev.Message).Msg("Cannot send event")
+					}
+				}()
 			case <-exitCh:
 				log.Info().Str("sink", name).Msg("Closing the sink")
 				break Loop

--- a/pkg/exporter/channel_registry_test.go
+++ b/pkg/exporter/channel_registry_test.go
@@ -1,0 +1,62 @@
+package exporter
+
+import (
+	"context"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
+	"github.com/stretchr/testify/assert"
+)
+
+type SlowSink struct {
+	wg   *sync.WaitGroup
+	rcvd []*kube.EnhancedEvent
+}
+
+func NewSlowSink() *SlowSink {
+	var rcvd []*kube.EnhancedEvent
+	return &SlowSink{
+		rcvd: rcvd,
+		wg:   &sync.WaitGroup{},
+	}
+}
+
+func (s *SlowSink) Send(ctx context.Context, event *kube.EnhancedEvent) error {
+	s.wg.Add(1)
+	time.Sleep(2 * time.Second)
+	s.rcvd = append(s.rcvd, event)
+	s.wg.Done()
+	return nil
+}
+
+func (s *SlowSink) Close() {
+	s.wg.Wait()
+}
+
+func AlmostEqualDuration(a time.Duration, b time.Duration, equalityThreshold time.Duration) bool {
+	diff := math.Abs(float64(a) - float64(b))
+	return diff <= float64(equalityThreshold)
+}
+
+func TestSendEventAsync(t *testing.T) {
+	name := "test"
+	cr := &ChannelBasedReceiverRegistry{}
+	sink := NewSlowSink()
+	cr.Register(name, sink)
+	ev := &kube.EnhancedEvent{}
+
+	start := time.Now()
+	cr.SendEvent(name, ev)
+	cr.SendEvent(name, ev)
+	cr.SendEvent(name, ev)
+	// Sleep for a very short period to ensure that
+	// all events have been sent to the sink channels
+	time.Sleep(10 * time.Millisecond)
+	cr.Close()
+	elapsed := time.Since(start)
+	assert.True(t, len(sink.rcvd) == 3)
+	assert.True(t, AlmostEqualDuration(elapsed, 2*time.Second, 200*time.Millisecond))
+}


### PR DESCRIPTION
We noticed that the Webhook sink was executing very slowly for high throughput events and concluded it was because the http requests were being executed synchronously. This commit fixes this by making the loop run in a go routine so it is not blocking.

I also added a quick test with a dummy slow sink.

Let me know if this change makes sense! :raised_hands: 