### PR TITLE
avoid logging at the error level the errors involving CRD

### DIFF
--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -33,7 +33,7 @@ func NewEventWatcher(config *rest.Config, namespace string, throttlePeriod int64
 		labelCache:      NewLabelCache(config),
 		annotationCache: NewAnnotationCache(config),
 		fn:              fn,
-		throttlePeriod:  time.Second*time.Duration(throttlePeriod),
+		throttlePeriod:  time.Second * time.Duration(throttlePeriod),
 	}
 
 	informer.AddEventHandler(watcher)
@@ -72,7 +72,11 @@ func (e *EventWatcher) onEvent(event *corev1.Event) {
 
 	labels, err := e.labelCache.GetLabelsWithCache(&event.InvolvedObject)
 	if err != nil {
-		log.Error().Err(err).Msg("Cannot list labels of the object")
+		if ev.InvolvedObject.Kind != "CustomResourceDefinition" {
+			log.Error().Err(err).Msg("Cannot list labels of the object")
+		} else {
+			log.Debug().Err(err).Msg("Cannot list labels of the object (CRD)")
+		}
 		// Ignoring error, but log it anyways
 	} else {
 		ev.InvolvedObject.Labels = labels
@@ -81,7 +85,11 @@ func (e *EventWatcher) onEvent(event *corev1.Event) {
 
 	annotations, err := e.annotationCache.GetAnnotationsWithCache(&event.InvolvedObject)
 	if err != nil {
-		log.Error().Err(err).Msg("Cannot list annotations of the object")
+		if ev.InvolvedObject.Kind != "CustomResourceDefinition" {
+			log.Error().Err(err).Msg("Cannot list annotations of the object")
+		} else {
+			log.Debug().Err(err).Msg("Cannot list annotations of the object (CRD)")
+		}
 	} else {
 		ev.InvolvedObject.Annotations = annotations
 		ev.InvolvedObject.ObjectReference = *event.InvolvedObject.DeepCopy()


### PR DESCRIPTION
When kubernetes-event-exporter is deployed on a cluster with many CRD (custom resource definitions) and its default clusterrole doesn't account for them, it then starts logging a ton of errors and this can cause problems (like saturation of storage if you are ingesting your logs from the kubernetes cluster). 
I think a better approach is to log errors involving CRD at the debugging level. So you can fix your clusterrole and avoid being overwhelmed by errors.
