### PR TITLE
fix: add kubernetes client QPS and Burst config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,5 +1,8 @@
 logLevel: debug
 logFormat: json
+throttlePeriod: 10
+kubeQPS: 60
+kubeBurst: 60
 # namespace: my-namespace-only # Omitting it defaults to all namespaces.
 route:
   # Main route
@@ -7,8 +10,8 @@ route:
     # This route allows dumping all events because it has no fields to match and no drop rules.
     - match:
         - receiver: "dump"
-    # This starts another route, drops all the events in *test* namespaces and Normal events 
-    # for capturing critical events 
+    # This starts another route, drops all the events in *test* namespaces and Normal events
+    # for capturing critical events
     - drop:
         - namespace: "*test*"
         - type: "Normal"
@@ -17,10 +20,10 @@ route:
         - receiver: "pipe"
     # This a final route for user messages
     - match:
-      - kind: "Pod|Deployment|ReplicaSet"
-        labels:
-          version: "dev"
-        receiver: "slack"
+        - kind: "Pod|Deployment|ReplicaSet"
+          labels:
+            version: "dev"
+          receiver: "slack"
 receivers:
   - name: "dump"
     elasticsearch:

--- a/main.go
+++ b/main.go
@@ -65,6 +65,8 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("cannot get kubeconfig")
 	}
+	kubeconfig.QPS = cfg.KubeQPS
+	kubeconfig.Burst = cfg.KubeBurst
 
 	engine := exporter.NewEngine(&cfg, &exporter.ChannelBasedReceiverRegistry{})
 	w := kube.NewEventWatcher(kubeconfig, cfg.Namespace, cfg.ThrottlePeriod, engine.OnEvent)

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -12,11 +12,14 @@ type Config struct {
 	// TODO: I am not sure what to do here.
 	LogLevel       string                    `yaml:"logLevel"`
 	LogFormat      string                    `yaml:"logFormat"`
-	ThrottlePeriod int64					 `yaml:"throttlePeriod"`
+	ThrottlePeriod int64                     `yaml:"throttlePeriod"`
 	Namespace      string                    `yaml:"namespace"`
 	LeaderElection kube.LeaderElectionConfig `yaml:"leaderElection"`
 	Route          Route                     `yaml:"route"`
 	Receivers      []sinks.ReceiverConfig    `yaml:"receivers"`
+
+	KubeQPS   float32 `yaml:"kubeQPS,omitempty"`
+	KubeBurst int     `yaml:"kubeBurst,omitempty"`
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
This PR adds kubernetes client-go QPS and Burst configuration. Default value will be used if not configured.

Default settting only allows QPS=5, it might cause a lot of warnings like: 
> Waited for 1.194248853s due to client-side throttling, not priority and fairness
 
This can be a solution to #159.  