### PR TITLE
feat: support match event with namespace-labels

### DIFF
--- a/pkg/exporter/rule.go
+++ b/pkg/exporter/rule.go
@@ -15,18 +15,19 @@ func matchString(pattern, s string) bool {
 
 // Rule is for matching an event
 type Rule struct {
-	Labels      map[string]string
-	Annotations map[string]string
-	Message     string
-	APIVersion  string
-	Kind        string
-	Namespace   string
-	Reason      string
-	Type        string
-	MinCount    int32
-	Component   string
-	Host        string
-	Receiver    string
+	Labels          map[string]string
+	Annotations     map[string]string
+	NamespaceLabels map[string]string
+	Message         string
+	APIVersion      string
+	Kind            string
+	Namespace       string
+	Reason          string
+	Type            string
+	MinCount        int32
+	Component       string
+	Host            string
+	Receiver        string
 }
 
 // MatchesEvent compares the rule to an event and returns a boolean value to indicate
@@ -74,6 +75,20 @@ func (r *Rule) MatchesEvent(ev *kube.EnhancedEvent) bool {
 	if r.Annotations != nil && len(r.Annotations) > 0 {
 		for k, v := range r.Annotations {
 			if val, ok := ev.InvolvedObject.Annotations[k]; !ok {
+				return false
+			} else {
+				matches := matchString(v, val)
+				if !matches {
+					return false
+				}
+			}
+		}
+	}
+
+	// NamespaceLabels are also mutually exclusive, they all need to be present
+	if r.NamespaceLabels != nil && len(r.NamespaceLabels) > 0 {
+		for k, v := range r.NamespaceLabels {
+			if val, ok := ev.InvolvedObject.NamespaceLabels[k]; !ok {
 				return false
 			} else {
 				matches := matchString(v, val)

--- a/pkg/kube/event.go
+++ b/pkg/kube/event.go
@@ -21,6 +21,7 @@ func (e EnhancedEvent) DeDot() EnhancedEvent {
 	c.Annotations = dedotMap(e.Annotations)
 	c.InvolvedObject.Labels = dedotMap(e.InvolvedObject.Labels)
 	c.InvolvedObject.Annotations = dedotMap(e.InvolvedObject.Annotations)
+	c.InvolvedObject.NamespaceLabels = dedotMap(e.InvolvedObject.NamespaceLabels)
 	return c
 }
 
@@ -40,6 +41,7 @@ type EnhancedObjectReference struct {
 	corev1.ObjectReference `json:",inline"`
 	Labels                 map[string]string `json:"labels,omitempty"`
 	Annotations            map[string]string `json:"annotations,omitempty"`
+	NamespaceLabels        map[string]string `json:"namespaceLabels,omitempty"`
 }
 
 // ToJSON does not return an error because we are %99 confident it is JSON serializable.

--- a/pkg/kube/namespace_labels.go
+++ b/pkg/kube/namespace_labels.go
@@ -1,0 +1,52 @@
+package kube
+
+import (
+	"context"
+
+	lru "github.com/hashicorp/golang-lru"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type NamespaceLabelCache struct {
+	dynClient dynamic.Interface
+	clientset *kubernetes.Clientset
+
+	cache *lru.ARCCache
+}
+
+func NewNamespaceLabelCache(kubeconfig *rest.Config) *NamespaceLabelCache {
+	cache, err := lru.NewARC(1024)
+	if err != nil {
+		panic("cannot init cache: " + err.Error())
+	}
+	return &NamespaceLabelCache{
+		dynClient: dynamic.NewForConfigOrDie(kubeconfig),
+		clientset: kubernetes.NewForConfigOrDie(kubeconfig),
+		cache:     cache,
+	}
+}
+
+func (n *NamespaceLabelCache) GetNamespaceLabelsWithCache(nsName string) (map[string]string, error) {
+	if val, ok := n.cache.Get(nsName); ok {
+		return val.(map[string]string), nil
+	}
+
+	ns, err := n.clientset.CoreV1().Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
+	if err == nil {
+		nsLabels := ns.GetLabels()
+		n.cache.Add(nsName, nsLabels)
+		return nsLabels, nil
+	}
+
+	if errors.IsNotFound(err) {
+		var empty map[string]string
+		n.cache.Add(nsName, empty)
+		return nil, nil
+	}
+
+	return nil, err
+}


### PR DESCRIPTION
### What problem does this PR solve?
This PR closes #143.
The **side effect** is event-exporter may launch one more request to apiserver during handling an incoming event.

### Tests
I am running this patch on my own cluster for days, it works well.