### PR TITLE
Switch to gcr.io/distroless/static:nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD . /app
 WORKDIR /app
 RUN CGO_ENABLED=0 GOOS=linux GO11MODULE=on go build -mod=vendor -a -o /main .
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder --chown=nonroot:nonroot /main /kubernetes-event-exporter
 
 USER nonroot


### PR DESCRIPTION
Per the [gcr.io/distroless docs](https://github.com/GoogleContainerTools/distroless/blob/3fa91ba3a9f59cab0ca95e7abef7cf94e8b2c449/base/README.md#L7):

> Statically compiled applications (Go) that do not require libc can use the `gcr.io/distroless/static` image

Since this app is being compiled with `CGO_ENABLED=0`, this should be safe.

In addition (and what prompted me to make this change), the `base` image has critical vulnerabilities:

```
$ trivy image -s CRITICAL  kubernetes-event-exporter:master
2022-03-03T11:08:15.821+0900    INFO    Detected OS: debian
2022-03-03T11:08:15.821+0900    INFO    Detecting Debian vulnerabilities...
2022-03-03T11:08:15.824+0900    INFO    Number of language-specific files: 1
2022-03-03T11:08:15.824+0900    INFO    Detecting gobinary vulnerabilities...

kubernetes-event-exporter:master (debian 11.2)
==============================================
Total: 3 (CRITICAL: 3)

+---------+------------------+----------+-------------------+---------------+---------------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+---------+------------------+----------+-------------------+---------------+---------------------------------------+
| libc6   | CVE-2021-33574   | CRITICAL | 2.31-13+deb11u2   |               | glibc: mq_notify does                 |
|         |                  |          |                   |               | not handle separately                 |
|         |                  |          |                   |               | allocated thread attributes           |
|         |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-33574 |
+         +------------------+          +                   +---------------+---------------------------------------+
|         | CVE-2022-23218   |          |                   |               | glibc: Stack-based buffer overflow    |
|         |                  |          |                   |               | in svcunix_create via long pathnames  |
|         |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-23218 |
+         +------------------+          +                   +---------------+---------------------------------------+
|         | CVE-2022-23219   |          |                   |               | glibc: Stack-based buffer             |
|         |                  |          |                   |               | overflow in sunrpc clnt_create        |
|         |                  |          |                   |               | via a long pathname                   |
|         |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-23219 |
+---------+------------------+----------+-------------------+---------------+---------------------------------------+

kubernetes-event-exporter (gobinary)
====================================
Total: 0 (CRITICAL: 0)
```

After switching to `static`, these go away:

```
$ trivy image -s CRITICAL  kubernetes-event-exporter:distroless-static
2022-03-03T11:09:20.128+0900    INFO    Detected OS: debian
2022-03-03T11:09:20.128+0900    INFO    Detecting Debian vulnerabilities...
2022-03-03T11:09:20.128+0900    INFO    Number of language-specific files: 1
2022-03-03T11:09:20.128+0900    INFO    Detecting gobinary vulnerabilities...

kubernetes-event-exporter:distroless-static (debian 11.2)
=========================================================
Total: 0 (CRITICAL: 0)


kubernetes-event-exporter (gobinary)
====================================
Total: 0 (CRITICAL: 0)
```