### PR TITLE
fix the env proxy support for webhook transport

### DIFF
--- a/pkg/sinks/webhook.go
+++ b/pkg/sinks/webhook.go
@@ -50,6 +50,7 @@ func (w *Webhook) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 	}
 	client := http.DefaultClient
 	client.Transport = &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: tlsClientConfig,
 	}
 	resp, err := client.Do(req)


### PR DESCRIPTION
Because the webhook used http.DefaultTransport which supports http.ProxyFromEnvironment in v0.10.