### PR TITLE
fix: GetTimestampMs handles different event timestamp

### DIFF
--- a/pkg/kube/event.go
+++ b/pkg/kube/event.go
@@ -2,9 +2,10 @@ package kube
 
 import (
 	"encoding/json"
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 type EnhancedEvent struct {
@@ -50,10 +51,20 @@ func (e *EnhancedEvent) ToJSON() []byte {
 }
 
 func (e *EnhancedEvent) GetTimestampMs() int64 {
-	return e.FirstTimestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+	timestamp := e.FirstTimestamp.Time
+	if timestamp.IsZero() {
+		timestamp = e.EventTime.Time
+	}
+
+	return timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
 }
 
 func (e *EnhancedEvent) GetTimestampISO8601() string {
+	timestamp := e.FirstTimestamp.Time
+	if timestamp.IsZero() {
+		timestamp = e.EventTime.Time
+	}
+
 	layout := "2006-01-02T15:04:05.000Z"
-	return e.FirstTimestamp.Format(layout)
+	return timestamp.Format(layout)
 }

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -33,7 +33,7 @@ func NewEventWatcher(config *rest.Config, namespace string, throttlePeriod int64
 		labelCache:      NewLabelCache(config),
 		annotationCache: NewAnnotationCache(config),
 		fn:              fn,
-		throttlePeriod:  time.Second*time.Duration(throttlePeriod),
+		throttlePeriod:  time.Second * time.Duration(throttlePeriod),
 	}
 
 	informer.AddEventHandler(watcher)
@@ -54,7 +54,11 @@ func (e *EventWatcher) OnUpdate(oldObj, newObj interface{}) {
 func (e *EventWatcher) onEvent(event *corev1.Event) {
 	// TODO: Re-enable this after development
 	// It's probably an old event we are catching, it's not the best way but anyways
-	if time.Since(event.LastTimestamp.Time) > e.throttlePeriod {
+	timestamp := event.LastTimestamp.Time
+	if timestamp.IsZero() {
+		timestamp = event.EventTime.Time
+	}
+	if time.Since(timestamp) > e.throttlePeriod {
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: lob <pengyu@pingcap.com>

This PR fix #194 and #163, so that events from kube-scheduler can be handled properly.