### PR TITLE
Add a timeout to sending events to sinks

### DIFF
--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -10,13 +10,14 @@ type Config struct {
 	// Route is the top route that the events will match
 	// TODO: There is currently a tight coupling with route and config, but not with receiver config and sink so
 	// TODO: I am not sure what to do here.
-	LogLevel       string                    `yaml:"logLevel"`
-	LogFormat      string                    `yaml:"logFormat"`
-	ThrottlePeriod int64					 `yaml:"throttlePeriod"`
-	Namespace      string                    `yaml:"namespace"`
-	LeaderElection kube.LeaderElectionConfig `yaml:"leaderElection"`
-	Route          Route                     `yaml:"route"`
-	Receivers      []sinks.ReceiverConfig    `yaml:"receivers"`
+	LogLevel          string                    `yaml:"logLevel"`
+	LogFormat         string                    `yaml:"logFormat"`
+	ThrottlePeriod    int64                     `yaml:"throttlePeriod"`
+	Namespace         string                    `yaml:"namespace"`
+	LeaderElection    kube.LeaderElectionConfig `yaml:"leaderElection"`
+	Route             Route                     `yaml:"route"`
+	Receivers         []sinks.ReceiverConfig    `yaml:"receivers"`
+	SendTimeoutMillis int64                     `yaml:"sendTimeoutMillis"`
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
If a sink takes too long to process an event, goroutines can pile up. For example, intermittent Kafka latency can cause memory spikes because of Goroutine pileup.